### PR TITLE
Added support for Linux.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 	implementation 'io.vertx:vertx-web:4.3.4'
 	implementation 'io.vertx:vertx-web-client:4.3.4'
-	runtimeOnly 'ch.qos.logback:logback-classic:1.3.4'
+	implementation 'ch.qos.logback:logback-classic:1.3.4'
 	
 	testImplementation 'io.vertx:vertx-unit:4.3.4'
 	testImplementation 'junit:junit:4.13.1'

--- a/build.gradle
+++ b/build.gradle
@@ -9,15 +9,16 @@ repositories {
 dependencies {
 	implementation 'io.vertx:vertx-web:4.3.4'
 	implementation 'io.vertx:vertx-web-client:4.3.4'
-	implementation('org.apache.httpcomponents:fluent-hc:4.5.13') {
-		exclude group: 'commons-logging', module: 'commons-logging'
-	}
 	runtimeOnly 'ch.qos.logback:logback-classic:1.3.4'
-	runtimeOnly 'org.codehaus.janino:janino:3.1.8'
-	runtimeOnly 'org.slf4j:jcl-over-slf4j:2.0.1'
 	
 	testImplementation 'io.vertx:vertx-unit:4.3.4'
 	testImplementation 'junit:junit:4.13.1'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 test {

--- a/src/test/java/TestClass.java
+++ b/src/test/java/TestClass.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
@@ -36,11 +38,14 @@ import io.vertx.ext.web.handler.LoggerHandler;
 @RunWith(VertxUnitRunner.class)
 public class TestClass {
 	
+	private static final Logger LOGGER = LoggerFactory.getLogger(TestClass.class);
+	
 	private static final int HTTP_SERVER_PORT = Integer.getInteger("HTTP_SERVER_PORT", 9090);
 	private static final int LOADBALANCER_PORT = Integer.getInteger("LOADBALANCER_PORT", 9091);
 	private static final boolean LOG_ACTIVITY = Boolean.getBoolean("LOG_ACTIVITY");
 	
-	public static Future<HttpServer> startVertxHttpServer(Vertx vertx, int port, boolean logActivity) {
+	private static Future<HttpServer> startVertxHttpServer(Vertx vertx, int port, boolean logActivity) {
+		LOGGER.info("Starting Vert.x HttpServer.");
 		HttpServer httpServer = vertx.createHttpServer(new HttpServerOptions()
 				.setHost("localhost")
 				.setPort(port)
@@ -53,11 +58,14 @@ public class TestClass {
 				.handler(routingContext -> routingContext.response()
 						.end());
 		return httpServer.requestHandler(router)
-				.listen();
+				.listen()
+				.onSuccess(ignore -> LOGGER.info("Vert.x HttpServer successfully started."))
+				.onFailure(cause -> LOGGER.error("Failed to start Vert.x HttpServer.", cause));
 	}
 	
-	public static Future<String> startNginxLoadbalancer(Vertx vertx, int loadbalancerPort, int serverPort) {
-		return vertx.executeBlocking(promise -> {
+	private static Future<String> startNginxLoadbalancer(Vertx vertx, int loadbalancerPort, int serverPort) {
+		return vertx.<String>executeBlocking(promise -> {
+			LOGGER.info("Starting Nginx loadbalancer.");
 			try {
 				Path nginxConfTempFilePath = File.createTempFile("nginx", ".conf").toPath();
 				List<String> nginxConf = Arrays.asList(
@@ -73,55 +81,108 @@ public class TestClass {
 					"  }",
 					"  ",
 					"  upstream backend {",
-					"    server host.docker.internal:" + serverPort + ";",
+					"    server localhost:" + serverPort + ";",
 					"  }",
 					"  client_max_body_size 10M;",
 					"}"
 				);
+				LOGGER.info("Using nginx.conf:\n{}", String.join("\n", nginxConf));
 				Files.write(nginxConfTempFilePath, nginxConf, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
-				File outputTempFile = File.createTempFile("docker", null);
+				File outputTempFile = File.createTempFile("output", null);
+				File errorTempFile = File.createTempFile("error", null);
 				Process process = new ProcessBuilder()
-						.command("docker", "run", "--rm", "--detach", "--publish", loadbalancerPort + ":" + loadbalancerPort, "--volume", nginxConfTempFilePath + ":/etc/nginx/nginx.conf:ro", "nginx")
+						.command("docker", "run", "--rm", "--detach", "--network", "host", "--volume", nginxConfTempFilePath + ":/etc/nginx/nginx.conf:ro", "nginx")
 						.redirectOutput(outputTempFile)
-						.redirectError(Redirect.INHERIT)
+						.redirectError(errorTempFile)
 						.start();
-				if (process.waitFor() == 0)
-					promise.complete(Files.readAllLines(outputTempFile.toPath()).get(0));
-				else
-					promise.fail("Command 'docker run' failed (" + process.exitValue() +").");
+				if (process.waitFor() == 0) {
+					LOGGER.info("Successfully started Nginx loadbalancer.");
+					promise.complete(Files.readString(outputTempFile.toPath(), StandardCharsets.UTF_8).strip());
+				}
+				else {
+					LOGGER.error("Failed to start Nginx loadbalancer. Process returned with exit code {}.", process.exitValue());
+					LOGGER.error(Files.readString(errorTempFile.toPath(), StandardCharsets.UTF_8).strip());
+					promise.fail(process.info().toString());
+				}
 			}
-			catch (Throwable t) {
-				promise.fail(t);
+			catch (Throwable cause) {
+				LOGGER.error("Failed to start Nginx loadbalancer.", cause);
+				promise.fail(cause);
 			}
 		});
 	}
 	
-	public static Future<Void> stopNginxLoadbalancer(Vertx vertx, String containerId) {
+	private static Future<String> waitForInitializationOfNginxLoadbalancer(Vertx vertx, String containerId) {
 		return vertx.executeBlocking(promise -> {
+			LOGGER.info("Waiting for initialization of Nginx loadbalancer.");
 			try {
-				System.out.println("### Logs from Nginx loadbalancer ###");
+				File outputTempFile = File.createTempFile("output", null);
+				File errorTempFile = File.createTempFile("error", null);
+				for (Future<String> future = promise.future(); !future.isComplete(); ) {
+					Process process = new ProcessBuilder()
+							.command("docker", "logs", containerId)
+							.redirectOutput(outputTempFile)
+							.redirectError(errorTempFile)
+							.start();
+					if (process.waitFor() == 0) {
+						if (Files.readString(outputTempFile.toPath(), StandardCharsets.UTF_8).contains("Configuration complete; ready for start up")) {
+							LOGGER.info("Nginx loadbalancer is up and running.");
+							promise.complete(containerId);
+						}
+					}
+					else {
+						LOGGER.error("Failed to wait for initialization of Nginx loadbalancer. Process returned with exit code {}.", process.exitValue());
+						LOGGER.error(Files.readString(errorTempFile.toPath(), StandardCharsets.UTF_8).strip());
+						promise.fail(process.info().toString());
+					}
+				}
+			}
+			catch (Throwable cause) {
+				LOGGER.error("Failed to wait for initialization of Nginx loadbalancer.", cause);
+				promise.fail(cause);
+			}
+		});
+	}
+	
+	private static Future<Void> stopNginxLoadbalancer(Vertx vertx, String containerId) {
+		return vertx.executeBlocking(promise -> {
+			LOGGER.info("Stopping Nginx loadbalancer.");
+			try {
+				File outputTempFile = File.createTempFile("output", null);
 				new ProcessBuilder()
 						.command("docker", "logs", containerId)
-						.inheritIO()
+						.redirectOutput(outputTempFile)
+						.redirectError(Redirect.DISCARD)
 						.start()
 						.waitFor();
-				System.out.println("### Logs from Nginx loadbalancer ###");
+				String logs = Files.readString(outputTempFile.toPath(), StandardCharsets.UTF_8);
+				if (!logs.isBlank())
+					LOGGER.info("Logs from Nginx loadbalancer:\n{}", logs);
+				outputTempFile = File.createTempFile("output", null);
+				File errorTempFile = File.createTempFile("error", null);
 				Process process = new ProcessBuilder()
 						.command("docker", "stop", containerId)
-						.inheritIO()
+						.redirectOutput(outputTempFile)
+						.redirectError(errorTempFile)
 						.start();
-				if (process.waitFor() == 0)
+				if (process.waitFor() == 0) {
+					LOGGER.info("Nginx loadbalancer successfully stopped.");
 					promise.complete();
-				else
-					promise.fail("Command 'docker stop' failed (" + process.exitValue() +").");
+				}
+				else {
+					LOGGER.error("Failed to stop Nginx loadbalancer. Process returned with exit code {}.", process.exitValue());
+					LOGGER.error(Files.readString(errorTempFile.toPath(), StandardCharsets.UTF_8).strip());
+					promise.fail(process.info().toString());
+				}
 			}
-			catch (Throwable t) {
-				promise.fail(t);
+			catch (Throwable cause) {
+				LOGGER.error("Failed to stop Nginx loadbalancer.", cause);
+				promise.fail(cause);
 			}
 		});
 	}
 	
-	public static class StatusCodes {
+	private static class StatusCodes {
 		
 		private List<Integer> list;
 		
@@ -153,7 +214,8 @@ public class TestClass {
 		
 	}
 	
-	public static Future<StatusCodes> runWebClient(Vertx vertx, int port, boolean logActivity, TestContext context) {
+	private static Future<StatusCodes> runWebClient(Vertx vertx, int port, boolean logActivity, TestContext context) {
+		LOGGER.info("Running Vert.x WebCient.");
 		HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions()
 				.setLogActivity(logActivity));
 		WebClient webClient = WebClient.wrap(httpClient, new WebClientOptions()
@@ -202,7 +264,7 @@ public class TestClass {
 		Vertx vertx = runTestOnContext.vertx();
 		Future<HttpServer> httpServerFuture = startVertxHttpServer(vertx, HTTP_SERVER_PORT, LOG_ACTIVITY);
 		Future<String> loadbalancerFuture = startNginxLoadbalancer(vertx, LOADBALANCER_PORT, HTTP_SERVER_PORT);
-		CompositeFuture.all(httpServerFuture, loadbalancerFuture)
+		CompositeFuture.all(httpServerFuture, loadbalancerFuture.compose(containerId -> waitForInitializationOfNginxLoadbalancer(vertx, containerId)))
 				.compose(futures -> runWebClient(vertx, LOADBALANCER_PORT, LOG_ACTIVITY, context))
 				.eventually(ignore -> CompositeFuture.join(httpServerFuture.compose(HttpServer::close), loadbalancerFuture.compose(containerId -> stopNginxLoadbalancer(vertx, containerId))))
 				.onComplete(context.asyncAssertSuccess(statusCodes -> context.assertEquals(new StatusCodes(200, 200, 200, 413, 200, 200, 200), statusCodes)));


### PR DESCRIPTION
On Linux, added --add-host=host.docker.internal:host-gateway to Docker command used for running Nginx. 
Added additional logging.
Removed unused dependencies since the issue can be reproduced using Vert.x WebClient, i.e., Apache HttpComponents HttpClient is not required for reproducing the issue.